### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class ServerlessPlugin {
           seed: {
             required: false,
             usage: 'The name of the seed to be used',
+            type: 'string',
           },
         }
       },


### PR DESCRIPTION
Fix for serverless deprecation warning

Serverless shows this warning:
Deprecation warning: CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
    - ServerlessPlugin for "seed"
Please report this issue in plugin issue tracker. Starting with next major release, this will be communicated with a thrown error. More Info: https://www.serverless.com/framework/docs/deprecations/#CLI_OPTIONS_SCHEMA

